### PR TITLE
Fix : home 페이지 생성. 다만 RootLayout은 계속 사용하는 것으로 진행

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
-    <main>
+    <section>
       <h1 className="text-green-500">Hello World!!!!!</h1>
-    </main>
+    </section>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,12 +15,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko">
       <body className={inter.className}>
-        <main className="flex ">
+        <div className="flex">
           <LeftSidebar />
           {children}
-        </main>
-        <Bottombar />
+        </div>
       </body>
+      <Bottombar />
     </html>
   );
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,7 +7,7 @@ export const sidebarLinks = [
   {
     icon: HiOutlineHome,
     label: "Home",
-    route: "/",
+    route: "/home",
   },
   {
     icon: FiMapPin,


### PR DESCRIPTION
- home 페이지에서 하위 layout 을 사용하려고 했으나, 기존처럼 유지하는게 낫다고 판단됨.
- entrance / signup / signin 페이지를 조건부 렌더링 같은 방식을 통해 사이드바, 하단바 없이 전체화면에서 표시할 수 있도록 하는게 더 좋을 것 같음.