### PR TITLE
Recommend : 식당 상세 정보 페이지 구현 및 카카오 지도 API 적용

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,28 @@ const nextConfig = {
   experimental: {
     appDir: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'cloudflare-ipfs.com',
+        port: '',
+        pathname: '/ipfs/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+        port: '',
+        pathname: '/seed/**',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "foodie-log-client-1",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tanstack/react-query": "^4.32.6",
         "@types/node": "20.4.9",
         "@types/react": "18.2.20",
@@ -23,6 +24,7 @@
         "react-dom": "18.2.0",
         "react-hook-form": "^7.45.4",
         "react-icons": "^4.10.1",
+        "react-kakao-maps-sdk": "^1.1.11",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.1.6",
@@ -394,6 +396,14 @@
       "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/aspect-ratio": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
+      "integrity": "sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -2494,6 +2504,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.38.tgz",
+      "integrity": "sha512-ub3ITsp/XfM7OikRvnsQiK6oZgyqVKVvGm9bmChudfDRjFa6xrS2O/bLNs0EyFCQZufVBXLLJK9+T06LOYxNiw=="
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -3231,6 +3246,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.11.tgz",
+      "integrity": "sha512-L3hHa7tvVCxEvU3R4DODctLQMNMEqUUkWweSgVrD/9qndeB3+Fk5FUUFRW5muVghwr4PQ2fzR1jhk6vO35TDaA==",
+      "dependencies": {
+        "kakao.maps.d.ts": "^0.1.38"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tanstack/react-query": "^4.32.6",
     "@types/node": "20.4.9",
     "@types/react": "18.2.20",
@@ -24,6 +25,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
+    "react-kakao-maps-sdk": "^1.1.11",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.1.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import "../styles/globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -10,9 +9,12 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+
+  
   return (
     <html lang="ko">
       <body className={inter.className}>
+
         <div>{children}</div>
       </body>
     </html>

--- a/src/app/main/layout.tsx
+++ b/src/app/main/layout.tsx
@@ -1,10 +1,20 @@
 import LeftSidebar from "../../components/LeftSidebar";
 import Bottombar from "../../components/Bottombar";
+import Script from "next/script";
+const NEXT_PUBLIC_KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY;
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
+  if (!NEXT_PUBLIC_KAKAO_MAP_API_KEY) {
+    throw new Error("KAKAO MAP API KEY is not defined!");
+  }
+
   return (
     <>
-      <div className="flex w-full">
+      <Script
+          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${NEXT_PUBLIC_KAKAO_MAP_API_KEY}&libraries=services,clusterer&autoload=false`}
+          strategy="beforeInteractive"
+        />
+      <div className="flex mx-auto">
         <LeftSidebar />
         <div className="w-full h-full flex justify-center">{children}</div>
       </div>

--- a/src/app/main/recommend/page.tsx
+++ b/src/app/main/recommend/page.tsx
@@ -1,4 +1,3 @@
-"use client"
 import AreaSelector from '@/src/components/AreaSelector'
 import Bottombar from '@/src/components/Bottombar'
 import ShopThumbList from '@/src/components/ShopThumbList'

--- a/src/app/main/restaurants/[id]/page.tsx
+++ b/src/app/main/restaurants/[id]/page.tsx
@@ -1,0 +1,11 @@
+import RestaurantDetail from '@/src/components/RestaurantDetail'
+
+const restaurant = () => {
+  return (
+    <div className='w-full bg-orange-500 flex justify-center'>
+      <RestaurantDetail />
+    </div>
+  )
+}
+
+export default restaurant

--- a/src/components/AreaSelector.tsx
+++ b/src/components/AreaSelector.tsx
@@ -1,3 +1,4 @@
+"use client"
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { area } from "@/src/constants";
@@ -75,7 +76,7 @@ const AreaSelector: React.FC<AreaSelectorProps> = ({ onSelectedAreaChange }) => 
   }, [selectedRegion, selectedDo, selectedSiGunGu, onSelectedAreaChange]);
 
   return (
-    <div className={`w-full sticky border-b border-solid item-center 
+    <div className={`z-20 w-full sticky border-b border-solid item-center 
      bg-white border border-gray-300 sm:rounded-md p-1 m-0 sm:m-4 sm:w-[480px]
      ${isVisible ? "top-0" : "-top-16"} transition-top duration-300`}>
       <div className="flex items-center justify-evenly w-full">

--- a/src/components/Bottombar.tsx
+++ b/src/components/Bottombar.tsx
@@ -7,7 +7,7 @@ const Bottombar = () => {
   const pathname = usePathname();
 
   return (
-    <section className="bottombar fixed bottom-0 w-full z-10 py-2 border-t-[1px] bg-white border-solid sm:hidden">
+    <section className="bottombar fixed bottom-0 w-full max-w-screen-sm mx-auto z-10 py-2 border-t-[1px] bg-white border-solid sm:hidden">
       <div className="bottombar_container flex justify-around ">
         {sidebarLinks
           .filter((link) => link.label !== "Search" && link.label !== "Notification")

--- a/src/components/Button/BackButtonMain.tsx
+++ b/src/components/Button/BackButtonMain.tsx
@@ -1,0 +1,22 @@
+"use client"
+import { LiaAngleLeftSolid } from "react-icons/lia";
+import { useRouter } from 'next/navigation'; 
+
+const BackButtonMain = () => {
+
+  const router = useRouter();  // useRouter를 사용하여 router 객체를 가져옴
+
+  const goBack = () => {
+    router.back();  // router의 back() 메서드를 사용하여 뒤로 가기
+  };
+
+  return (
+    <div className="mb-2 sm:hidden">
+      <button type="button" className="w-20 pl-4" onClick={goBack}>
+        <LiaAngleLeftSolid size="1.7rem" className="hover:text-orange-600" />
+      </button>
+    </div>
+  );
+};
+
+export default BackButtonMain;

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useState } from "react";
 import { FeedData } from "../types/apiTypes";
 import { BsThreeDotsVertical } from "react-icons/bs";
@@ -9,7 +10,7 @@ import { FaRegCommentDots } from "react-icons/fa";
 import { FiShare2 } from "react-icons/fi";
 import { getIcon } from "../utils/iconUtils";
 import Button from "./Button";
-import ShopCard from './ShopCard';
+import ShopCard from "./ShopCard";
 
 const Feed: React.FC<FeedData> = ({ feed, restaurant, isFollowed, isLiked }) => {
   const timeDifference = getTimeDiff(dayjs(feed.createdAt));
@@ -29,12 +30,16 @@ const Feed: React.FC<FeedData> = ({ feed, restaurant, isFollowed, isLiked }) => 
     <div className="mt-2 w-full max-w-[640px] bg-mint-light border rounded-sm px-2">
       {/* Header */}
       <div className="flex items-center p-3">
-        <img
-          src={feed.profileImageUrl}
-          alt="사용자 썸네일"
-          className="w-12 h-12 border p-1 mr-3 rounded-full cursor-pointer"
-        />
-        <div className="flex flex-1 flex-col">
+        <div className="relative w-12 h-12">
+          <Image
+            fill={true}
+            src={feed.profileImageUrl}
+            alt="사용자 썸네일"
+            sizes="(max-width: 48px) 48px, 48px"
+            className="w-12 h-12 border p-1 rounded-full cursor-pointer"
+          />
+        </div>
+        <div className="flex flex-1 flex-col ml-3">
           <p className="font-bold  cursor-pointer">{feed.nickName}</p>
           <p className="text-sm">{timeDifference}</p>
         </div>
@@ -55,6 +60,7 @@ const Feed: React.FC<FeedData> = ({ feed, restaurant, isFollowed, isLiked }) => 
       <ImageSlide images={feed.feedImages} />
       {/* restaurant */}
       <ShopCard
+        id={restaurant.id}
         name={restaurant.name}
         category={restaurant.category}
         roadAddress={restaurant.roadAddress}

--- a/src/components/Feeds.tsx
+++ b/src/components/Feeds.tsx
@@ -4,44 +4,12 @@ import { faker } from "@faker-js/faker";
 import Feed from "./Feed";
 import { useEffect, useState } from "react";
 import { FeedData } from '../types/apiTypes';
+import { generateFeedDummyData } from '../utils/dummyDataUtils';
 
 const Feeds = () => {
   const [dummyFeedsData, setDummyFeedsData] = useState<FeedData[]>([]);
   useEffect(() => {
-    const DUMMY_DATA = [...Array(10)].map((_, i) => ({
-      feed: {
-        id: faker.number.int({ max: 1000000 }),
-        nickName: faker.person.firstName(),
-        profileImageUrl: faker.image.avatar(),
-        createdAt: faker.date.recent(),
-        updateAt: faker.date.recent(),
-        feedImages: [
-          {
-            ImageUrl: faker.image.urlPicsumPhotos(),
-          },
-          {
-            ImageUrl: faker.image.urlPicsumPhotos(),
-          },
-          {
-            ImageUrl: faker.image.urlPicsumPhotos(),
-          },
-        ],
-        content: faker.lorem.paragraph(2),
-        likeCount: faker.number.int({ max: 1000 }), //좋아요 개수
-        replyCount: faker.number.int({ max: 5 }), //댓글 개수
-        share: "URL",
-      },
-      restaurant: {
-        id: faker.number.int({ max: 1000 }),
-        name: faker.company.name(),
-        category: faker.commerce.department(),
-        link: faker.internet.url(),
-        roadAddress: faker.location.streetAddress(),
-      },
-      isFollowed: faker.datatype.boolean(),
-      isLiked: faker.datatype.boolean(), //좋아요
-    }));
-
+    const DUMMY_DATA = generateFeedDummyData();
     setDummyFeedsData(DUMMY_DATA);
   }, []);
 

--- a/src/components/KakaoMap.tsx
+++ b/src/components/KakaoMap.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useRef, useEffect, useState } from "react";
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+
+const KakaoMap = ({ latitude, longitude }) => {
+  const mapRef = useRef();
+
+  // 초기 크기 설정
+  let initialWidth;
+  if (typeof window !== "undefined") {
+    initialWidth = window.innerWidth > 640 ? "640px" : `${window.innerWidth}px`;
+    console.log("initialWidth:", initialWidth);
+  }
+  const [mapSize, setMapSize] = useState({
+    width: "640px",
+    height: "640px",
+  });
+
+  const parsedLat = parseFloat(latitude);
+  const parsedLng = parseFloat(longitude);
+
+  const handleResize = () => {
+    const windowWidth = window.innerWidth;
+    let newSize;
+    if (windowWidth <= 640) {
+      newSize = `${windowWidth}px`;
+    } else {
+      newSize = "640px";
+    }
+
+    setMapSize({
+      width: newSize,
+      height: newSize,
+    });
+  };
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (map) map.relayout();
+  }, [mapSize]);
+
+  useEffect(() => {
+    handleResize(); // 초기 로딩 시 사이즈 체크 및 적용
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return (
+    <div>
+      <div className="flex flex-col w-full items-center justify-center">
+        <Map center={{ lat: parsedLat, lng: parsedLng }} style={mapSize} ref={mapRef}>
+          <MapMarker position={{ lat: parsedLat, lng: parsedLng }}></MapMarker>
+        </Map>
+      </div>
+    </div>
+  );
+};
+
+export default KakaoMap;

--- a/src/components/RestaurantDetail.tsx
+++ b/src/components/RestaurantDetail.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useRouter, usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import BackButtonMain from "./Button/BackButtonMain";
+import KakaoMap from "./KakaoMap";
+import ShopCard from "./ShopCard";
+import Feeds from "./Feeds";
+import { generateRestaurantDetailDummyData } from "../utils/dummyDataUtils";
+
+const RestaurantDetail = () => {
+  const [restaurantDetail, setRestaurantDetail] = useState<any>();
+  const pathname = usePathname();
+
+  const restaurantIdMatch = pathname.match(/restaurants\/(\d+)/);
+  // FIXME: restaurantIdMatch가 null일 경우를 처리해야 함. 현재는 1로 지정함.
+  const restaurantId = restaurantIdMatch ? parseInt(restaurantIdMatch[1], 10) : 1;
+
+  useEffect(() => {
+    const data = generateRestaurantDetailDummyData();
+    setRestaurantDetail(data);
+  }, []);
+
+  if (!restaurantDetail) return <div>Loading...</div>;
+
+  return (
+
+    <div className="w-full flex flex-col justify-center max-w-screen-sm mx-auto">
+      <BackButtonMain />
+      <KakaoMap 
+        latitude={restaurantDetail.location.mapx}
+        longitude={restaurantDetail.location.mapy}  
+      />
+      <ShopCard
+        id={restaurantId}
+        name={restaurantDetail.name}
+        category={restaurantDetail.category}
+        roadAddress={restaurantDetail.roadAddress}
+        isLiked={restaurantDetail.isLiked}
+        shopUrl={restaurantDetail.link}
+      />
+      <Feeds />
+    </div>
+  );
+};
+
+export default RestaurantDetail;

--- a/src/components/ShopCard.tsx
+++ b/src/components/ShopCard.tsx
@@ -1,9 +1,12 @@
+import Link from "next/link";
 import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
 import { getIcon } from "../utils/iconUtils";
 import { FiExternalLink } from "react-icons/fi";
-import { useState } from 'react';
+import { useState } from "react";
+import Image from 'next/image';
 
 interface ShopCardProps {
+  id: number;
   name: string;
   category: string;
   roadAddress: string;
@@ -11,32 +14,50 @@ interface ShopCardProps {
   shopUrl?: string;
 }
 
-const ShopCard: React.FC<ShopCardProps>= ({name, category, roadAddress, isLiked, shopUrl}) => {
+const ShopCard: React.FC<ShopCardProps> = ({ id, name, category, roadAddress, isLiked, shopUrl }) => {
   const shopCategoryIcon = `/images/foodCategoryIcons/${getIcon(category)}`;
-  const [like, setLike] = useState(isLiked)
+  const [like, setLike] = useState(isLiked);
+
   return (
-    <div className='flex items-center'>
+    <div className="flex items-center justify-between px-4 py-2"> {/* Change flex layout to justify-between */}
       <div className="flex items-center">
-        <img src={shopCategoryIcon} alt="음식점 썸네일" className="w-12 h-12 border p-1 rounded-full cursor-pointer" />
-        <div className="flex flex-col items-start p-1">
-          <p className="font-bold text-base cursor-pointer">{name}</p>
-          <p className="text-base cursor-pointer">{roadAddress}</p>
+        <Link href={`/main/restaurants/${id}`}>
+        <div className="relative w-12 h-12">
+          <Image
+            fill
+            src={shopCategoryIcon}
+            alt="음식점 썸네일"
+            sizes="(max-width: 48px) 48px, 48px"
+            className="w-12 h-12 border rounded-full cursor-pointer"
+          />
+          </div>
+        </Link>
+        <div className="flex flex-col items-start p- ml-3">
+          <Link href={`/main/restaurants/${id}`}>
+            <p className="font-bold text-base cursor-pointer">{name}</p>
+          </Link>
+          <Link href={`/main/restaurants/${id}`}>
+            <p className="text-base cursor-pointer">{roadAddress}</p>
+          </Link>
         </div>
       </div>
-      <div className='flex flex-1'>
-        {isLiked !== undefined && (
-          <button className="text-[24px]" onClick={() => setLike(!like)}>
-            {like ? <AiFillHeart /> : <AiOutlineHeart />}
-          </button>
-        )}
-        {shopUrl && (
-          <a href={shopUrl} target="_blank" rel="noopener noreferrer">
-            <FiExternalLink className="text-[24px] cursor-pointer" />
-          </a>
-        )}
-      </div>
+      {(isLiked !== undefined || shopUrl) && ( // Adjust this condition to show the right section only when needed
+        <div className="flex items-center"> 
+          {isLiked !== undefined && (
+            <button className="text-[24px] mr-2" onClick={() => setLike(!like)}> {/* Add a margin for spacing */}
+              {like ? <AiFillHeart /> : <AiOutlineHeart />}
+            </button>
+          )}
+          {shopUrl && (
+            <a href={shopUrl} target="_blank" rel="noopener noreferrer">
+              <FiExternalLink className="text-[24px] cursor-pointer ml-4 mr-2" />
+            </a>
+          )}
+        </div>
+      )}
     </div>
   );
 };
+
 
 export default ShopCard;

--- a/src/components/ShopThumb.tsx
+++ b/src/components/ShopThumb.tsx
@@ -1,34 +1,30 @@
+import Link from "next/link";
 import { ShopThumbData } from "../types/apiTypes";
 import { getIcon } from "../utils/iconUtils";
-import ShopCard from './ShopCard';
+import ShopCard from "./ShopCard";
+import Image from "next/image";
 
 const ShopThumb: React.FC<ShopThumbData> = ({ id, name, category, roadAddress, feedList }) => {
   const shopCategoryIcon = `/images/foodCategoryIcons/${getIcon(category)}`;
 
   return (
     <div className="mt-2 w-full max-w-[640px] bg-gray-100 border rounded-sm px-1">
-      
-      <ShopCard name={name} category={category} roadAddress={roadAddress} />
-
-      {/* <div className="flex items-center">
-        <img src={shopCategoryIcon} alt="음식점 썸네일" className="w-12 h-12 border p-1 rounded-full cursor-pointer" />
-        <div className="flex flex-col items-start p-1">
-          <p className="font-bold text-base cursor-pointer">{name}</p>
-          <p className="text-sm cursor-pointer">{roadAddress}</p>
-        </div>
-      </div> */}
-      
-      
-      {/* <p className="text-sm p-1">{category}</p> */}
+      <ShopCard id={id} name={name} category={category} roadAddress={roadAddress} />
 
       <div className="flex gap-1">
         {feedList.map((feed) => (
           <div className="flex w-1/3" key={feed.id}>
-            <img
-              src={feed.thumbnailUrl}
-              alt="Feed thumbnail"
-              className="w-full h-full object-cover border rounded cursor-pointer"
-            />
+            <Link href={`/main/restaurants/${id}`}>
+              {/* {console.log(feed.thumbnailUrl)} */}
+              {/* FIXME : img 를 Image 컴포넌트로 바꾸기 */}
+                <img
+                  
+                  src={feed.thumbnailUrl}
+                  alt="Feed thumbnail"
+                  className="w-full h-full object-cover border rounded cursor-pointer"
+                />
+              
+            </Link>
           </div>
         ))}
       </div>

--- a/src/components/ShopThumbList.tsx
+++ b/src/components/ShopThumbList.tsx
@@ -1,32 +1,14 @@
+"use client"
 import ShopThumb from './ShopThumb';
 import { useState, useEffect } from 'react';
 import { faker } from "@faker-js/faker";
+import { generateShopDummyData } from '../utils/dummyDataUtils';
 
 const ShopThumbList = () => {
   const [dummyShopData, setDummyShopData] = useState<any[]>([]);
 
   useEffect(() => {
-    const DUMMY_DATA = [...Array(10)].map((_, i) => ({
-      id: faker.number.int({ max: 1000000 }),
-      name: faker.company.name(),
-      category: faker.commerce.department(),
-      roadAddress: faker.location.streetAddress(),
-      feedList: [
-        {
-          id: faker.number.int({ max: 1000000 }),
-          thumbnailUrl: faker.image.urlPicsumPhotos(),
-        },
-        {
-          id: faker.number.int({ max: 1000000 }),
-          thumbnailUrl: faker.image.urlPicsumPhotos(),
-        },
-        {
-          id: faker.number.int({ max: 1000000 }),
-          thumbnailUrl: faker.image.urlPicsumPhotos(),
-        },
-      ]
-    }));
-
+    const DUMMY_DATA = generateShopDummyData()
     setDummyShopData(DUMMY_DATA);
   }, []);
 

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,9 +1,8 @@
-"use client";
+"use client"
 import Image from "next/image";
 import { Logo } from "@/public/images";
 import { IoIosSearch, IoMdNotificationsOutline } from "react-icons/io";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import useHideOnScroll from '../hooks/useHideOnScroll';
 
 const Topbar = () => {

--- a/src/hooks/useHideOnScroll.ts
+++ b/src/hooks/useHideOnScroll.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState, useEffect } from "react";
 
 const useHideOnScroll = () => {

--- a/src/utils/dummyDataUtils.ts
+++ b/src/utils/dummyDataUtils.ts
@@ -1,0 +1,77 @@
+import { faker } from "@faker-js/faker";
+
+export const generateFeedDummyData = () => {
+  return [...Array(10)].map((_, i) => ({
+    feed: {
+      id: faker.number.int({ max: 1000000 }),
+      nickName: faker.person.firstName(),
+      profileImageUrl: faker.image.avatar(),
+      createdAt: faker.date.recent(),
+      updateAt: faker.date.recent(),
+      feedImages: [
+        {
+          ImageUrl: faker.image.urlPicsumPhotos(),
+        },
+        {
+          ImageUrl: faker.image.urlPicsumPhotos(),
+        },
+        {
+          ImageUrl: faker.image.urlPicsumPhotos(),
+        },
+      ],
+      content: faker.lorem.paragraph(2),
+      likeCount: faker.number.int({ max: 1000 }),
+      replyCount: faker.number.int({ max: 5 }),
+      share: "URL",
+    },
+    restaurant: {
+      id: faker.number.int({ max: 1000 }),
+      name: faker.company.name(),
+      category: faker.commerce.department(),
+      link: faker.internet.url(),
+      roadAddress: faker.location.streetAddress(),
+    },
+    isFollowed: faker.datatype.boolean(),
+    isLiked: faker.datatype.boolean(),
+  }));
+};
+
+
+export const generateShopDummyData = () => {
+  return [...Array(10)].map((_, i) => ({
+    id: faker.number.int({ max: 1000000 }),
+    name: faker.company.name(),
+    category: faker.commerce.department(),
+    roadAddress: faker.location.streetAddress(),
+    feedList: [
+      {
+        id: faker.number.int({ max: 1000000 }),
+        thumbnailUrl: faker.image.urlPicsumPhotos(),
+      },
+      {
+        id: faker.number.int({ max: 1000000 }),
+        thumbnailUrl: faker.image.urlPicsumPhotos(),
+      },
+      {
+        id: faker.number.int({ max: 1000000 }),
+        thumbnailUrl: faker.image.urlPicsumPhotos(),
+      },
+    ]
+  }));
+};
+
+export const generateRestaurantDetailDummyData = () => {
+  return {
+    name: faker.company.name(),
+    category: faker.commerce.department(),
+    link: faker.internet.url(),
+    roadAddress: faker.location.streetAddress(),
+    location: {
+      mapy: faker.location.latitude({ min: 126.5, max: 127.5, precision: 6 }),
+      mapx: faker.location.longitude({ min: 37, max: 38, precision: 6 }),
+    },
+    isLiked: faker.datatype.boolean(),
+    like_id: faker.number.int({ max: 1000000 }),
+    content: generateFeedDummyData(),
+  };
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,6 +37,8 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/aspect-ratio'),
+  ],
 };
 export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
     ],
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "types": [
+      "kakao.maps.d.ts"
+    ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
지도 API 에서 시간 지체를 많이 했네요. PR 리뷰 하기에는 양이 많아서, 아래 내용들만 읽어보시고 따로 이상 없으면 merge 부탁드립니다!

- Config : kakao.mpas.d.ts 를 tsconfig.json 에 추가함        
- Feat : 카카오 지도 api 추가함. 동적 크기 변경이 어려워서 고생중임
- Fix : img -> Image 컴포넌트로 변경. 그 외 ShopCard에 전달할 음식점 id 적용
- Feat : 식당 상세정보 페이지(RestaurantDetail) 레이아웃 구현 완료
- Design : css 수정. 바텀바에 max-w-screen 추가
- Feat : 음식점 정보 클릭시 식당 상세정보 페이지로 이동시킴. ShopCard 매개변수에 따른 레이아웃 조정
- Move : 카카오 지도 script를 RootLayout 에서 MainLayout 으로 이동시킴
- Refactor : faker js 더미데이터들을 모두 유틸 함수로 만들어 따로 보관함
- Modify : 클라이언트 컴포넌트에서 서버 컴포넌트로 변경
- Modify : 서버 컴포넌트에서 클라이언트 컴포넌트로 변경
- Feat : BackButton(메인에 사용가능) 컴포넌트 구현     
- Config : aspect-ratio를 tailwind config 에 plugin으로 추가함.
- Lib : taiwildcss/aspect-ratio 라이브러리 시험 추가. 나중에 지울 수도 있음.
- Add : 외부 이미지 url 적용을 위한 next.config.js 추가