### PR TITLE
refactor: 메인 피드 페이지의 카테고리화 및 리팩토링

### DIFF
--- a/src/app/main/feed/page.tsx
+++ b/src/app/main/feed/page.tsx
@@ -3,24 +3,20 @@ import Header from "@components/Common/Header";
 import Feeds from "@components/Feed/Feeds";
 import { useSearchParams } from "next/navigation";
 
-interface userFeedListProps {
-  params: {
-    id: string;
-  };
-}
-
 const UserSingleFeed = () => {
-  // 여기서 params가 아니라 쿼리스트링에서 값을 추출해야함.
-  // 여기에서 필요없는 부분은 지워주고 쿼리스트링에서 singleFeedId를 추출해오는 로직도 구현해줘.
   const params = useSearchParams();
-  const feedId = params.get("feedId") || undefined;
+  const feedId = params.get("feedId");
+  const isFeeds = params.get("feeds");
 
-  const singleFeedId = feedId ? Number(feedId) : undefined;
+  const feedsData = {
+    singleFeedId: isFeeds ? undefined : Number(feedId),
+    startingFeedId: isFeeds ? Number(feedId) : undefined,
+  };
 
   return (
     <div className="w-full max-w-[640px] mx-auto">
       <Header title="피드" back="prePage" />
-      <Feeds singleFeedId={singleFeedId} />
+      <Feeds {...feedsData} />
     </div>
   );
 };

--- a/src/app/main/home/page.tsx
+++ b/src/app/main/home/page.tsx
@@ -1,5 +1,5 @@
 import MainHeader from "@components/Common/Header/MainHeader";
-import FeedsCategoryList from "@/src/components/Feed/FeedsCategory";
+import FeedsCategoryList from "@components/Feed/FeedsCategoryList";
 
 const Home = () => {
   return (

--- a/src/app/main/home/page.tsx
+++ b/src/app/main/home/page.tsx
@@ -1,12 +1,12 @@
-import Feeds from "@components/Feed/Feeds";
 import MainHeader from "@components/Common/Header/MainHeader";
+import FeedsCategoryList from "@/src/components/Feed/FeedsCategory";
 
 const Home = () => {
   return (
     <div className="home_container w-full max-w-6xl mx-auto pb-[110px]">
       <section className="flex flex-col">
         <MainHeader />
-        <Feeds />
+        <FeedsCategoryList />
       </section>
     </div>
   );

--- a/src/app/main/restaurants/[restaurantId]/feed/page.tsx
+++ b/src/app/main/restaurants/[restaurantId]/feed/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import Feeds from "@/src/components/Feed/Feeds";
 import Header from "@components/Common/Header";
-import Feed from "@components/Feed/Feed";
 import useRestaurantDetailQuery from "@hooks/queries/useRestaurantDetailQuery";
 
 interface RestaurantFeedProps {
@@ -19,7 +19,7 @@ const RestaurantFeed = ({ params: { restaurantId } }: RestaurantFeedProps) => {
       <Header title="피드" back="prePage" />
       {data?.feedList.map((feedData) => (
         <div key={feedData.feed.feedId}>
-          <Feed {...feedData} />
+          <Feeds singleFeedId={feedData.feed.feedId} />
         </div>
       ))}
     </div>

--- a/src/components/Common/Button/FollowButton.tsx
+++ b/src/components/Common/Button/FollowButton.tsx
@@ -1,5 +1,6 @@
 import { UserPlus } from "@assets/icons";
 import useFollowMutations from "@hooks/mutations/useFollowMutaton";
+import { useParams } from "next/navigation";
 
 interface FollowButtonProps {
   isFollowed: boolean;
@@ -9,7 +10,9 @@ interface FollowButtonProps {
 }
 
 function FollowButton({ isFollowed, userId, className, icon = false }: FollowButtonProps) {
-  const { followMutation, unfollowMutation } = useFollowMutations(userId);
+  const params = useParams();
+  const restaurantId = typeof params.restaurantId === "string" ? parseInt(params.restaurantId, 10) : undefined;
+  const { followMutation, unfollowMutation } = useFollowMutations(userId, restaurantId);
 
   const clickFollowBtnHandler = async () => {
     if (isFollowed) {

--- a/src/components/Feed/FeedUserCard.tsx
+++ b/src/components/Feed/FeedUserCard.tsx
@@ -6,8 +6,9 @@ import { useUserStore } from "@store/useUserStore";
 
 interface FeedUserCardProps {
   data: FeedData["feed"];
+  timeStamp?: boolean;
 }
-function FeedUserCard({ data }: FeedUserCardProps) {
+function FeedUserCard({ data, timeStamp = true }: FeedUserCardProps) {
   const { id } = useUserStore((state) => state.user);
 
   return (
@@ -24,7 +25,7 @@ function FeedUserCard({ data }: FeedUserCardProps) {
         <Link href={data.userId === id ? "/main/mypage" : `/main/${data.userId}`}>
           <p className="text-[16px]">{data.nickName}</p>
         </Link>
-        <TimeStamp createdAt={data.createdAt} />
+        {timeStamp && <TimeStamp createdAt={data.createdAt} />}
       </div>
     </div>
   );

--- a/src/components/Feed/FeedUserCard.tsx
+++ b/src/components/Feed/FeedUserCard.tsx
@@ -7,23 +7,27 @@ import { useUserStore } from "@store/useUserStore";
 interface FeedUserCardProps {
   data: FeedData["feed"];
   timeStamp?: boolean;
+  small?: boolean;
 }
-function FeedUserCard({ data, timeStamp = true }: FeedUserCardProps) {
+function FeedUserCard({ data, timeStamp = true, small = false }: FeedUserCardProps) {
   const { id } = useUserStore((state) => state.user);
 
   return (
-    <div className="flex items-center">
-      <Link href={data.userId === id ? "/main/mypage" : `/main/${data.userId}`} className="relative w-12 h-12">
+    <div className={`flex items-center gap-${small ? 2 : 3}`}>
+      <Link
+        href={data.userId === id ? "/main/mypage" : `/main/${data.userId}`}
+        className={`relative w-${small ? 6 : 12} h-${small ? 6 : 12}`}
+      >
         <Image
           fill={true}
           src={data.profileImageUrl || "/images/userImage.png"}
           alt="사용자 썸네일"
-          className="w-12 h-12 rounded-full cursor-pointer"
+          className="fill rounded-full cursor-pointer"
         />
       </Link>
-      <div className="flex flex-1 flex-col ml-[12px] gap-[4px]">
+      <div className="flex flex-1 flex-col gap-1">
         <Link href={data.userId === id ? "/main/mypage" : `/main/${data.userId}`}>
-          <p className="text-[16px]">{data.nickName}</p>
+          <p className={`text-[${small ? 14 : 16}px] ${small && "text-gray-4"}`}>{data.nickName}</p>
         </Link>
         {timeStamp && <TimeStamp createdAt={data.createdAt} />}
       </div>

--- a/src/components/Feed/FeedsCategoryList.tsx
+++ b/src/components/Feed/FeedsCategoryList.tsx
@@ -39,7 +39,7 @@ const FeedsCategoryList = () => {
                     ></Image>
                   </Link>
                 </div>
-                <p className="text-gray-10">{feedData.feed.content}</p>
+                <p className="text-gray-10 whitespace-nowrap overflow-x-hidden truncate">{feedData.feed.content}</p>
                 <FeedUserCard data={feedData.feed} timeStamp={false} small />
               </div>
             ))}

--- a/src/components/Feed/FeedsCategoryList.tsx
+++ b/src/components/Feed/FeedsCategoryList.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import useFeedListQuery from "@hooks/queries/useFeedListQuery";
+import FeedsCategorySlider from "@components/Feed/FeedsCategorySlider";
+import Link from "next/link";
+import Image from "next/image";
+import FeedUserCard from "@components/Feed/FeedUserCard";
+import InfiniteScroll from "react-infinite-scroller";
+import { Content } from "@@types/feed";
+
+const FeedsCategoryList = () => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useFeedListQuery({});
+
+  if (isLoading) {
+    <div>Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-col pt-12 max-w-[640px] w-full mx-auto">
+      <FeedsCategorySlider />
+      <InfiniteScroll
+        pageStart={0}
+        loadMore={() => {
+          fetchNextPage();
+        }}
+        hasMore={hasNextPage && !isFetchingNextPage}
+      >
+        {data?.pages.map((page, pageIndex) => (
+          <div key={pageIndex} className="grid grid-cols-2 gap-4 mx-2 mt-2">
+            {page.response.content.map((feedData: Content, dataIndex) => (
+              <div key={dataIndex} className=" flex flex-col p-3 gap-3 border-gray-2 border-[1px] rounded-[10px]">
+                <div className="relative rounded-[10px] w-full aspect-w-1 aspect-h-1">
+                  <Link href={`/main/feed/?feedId=${feedData.feed.feedId}`}>
+                    <Image
+                      className="rounded-[10px]"
+                      src={feedData.feed.feedImages[0].imageUrl}
+                      fill
+                      alt="피드 이미지"
+                    ></Image>
+                  </Link>
+                </div>
+                <p className="text-gray-10">{feedData.feed.content}</p>
+                <FeedUserCard data={feedData.feed} timeStamp={false} />
+              </div>
+            ))}
+          </div>
+        ))}
+      </InfiniteScroll>
+    </div>
+  );
+};
+
+export default FeedsCategoryList;

--- a/src/components/Feed/FeedsCategoryList.tsx
+++ b/src/components/Feed/FeedsCategoryList.tsx
@@ -30,7 +30,7 @@ const FeedsCategoryList = () => {
             {page.response.content.map((feedData: Content, dataIndex) => (
               <div key={dataIndex} className=" flex flex-col p-3 gap-3 border-gray-2 border-[1px] rounded-[10px]">
                 <div className="relative rounded-[10px] w-full aspect-w-1 aspect-h-1">
-                  <Link href={`/main/feed/?feedId=${feedData.feed.feedId}`}>
+                  <Link href={`/main/feed/?feeds?feedId=${feedData.feed.feedId}`}>
                     <Image
                       className="rounded-[10px]"
                       src={feedData.feed.feedImages[0].imageUrl}

--- a/src/components/Feed/FeedsCategoryList.tsx
+++ b/src/components/Feed/FeedsCategoryList.tsx
@@ -40,7 +40,7 @@ const FeedsCategoryList = () => {
                   </Link>
                 </div>
                 <p className="text-gray-10">{feedData.feed.content}</p>
-                <FeedUserCard data={feedData.feed} timeStamp={false} />
+                <FeedUserCard data={feedData.feed} timeStamp={false} small />
               </div>
             ))}
           </div>

--- a/src/components/Feed/FeedsCategorySlider.tsx
+++ b/src/components/Feed/FeedsCategorySlider.tsx
@@ -1,0 +1,38 @@
+import { tagNames } from "@constants";
+import { motion } from "framer-motion";
+import { useState } from "react";
+
+const FeedsCategorySlider = () => {
+  const [selected, setSelected] = useState<string>("전체");
+
+  //TODO:selected된 데이터 필터링
+
+  const sliderVariants = {
+    hidden: { opacity: 0 },
+    visible: { opacity: 1 },
+  };
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={sliderVariants}
+      className="flex overflow-x-auto"
+      style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+    >
+      {["전체", ...tagNames].map((tagName) => (
+        <div key={tagName}>
+          <button
+            className={`flex p-[10px] whitespace-nowrap ${selected === tagName && "border-b-2 border-red"}  `}
+            onClick={() => {
+              setSelected(tagName);
+            }}
+          >
+            {tagName}
+          </button>
+        </div>
+      ))}
+    </motion.div>
+  );
+};
+
+export default FeedsCategorySlider;

--- a/src/hooks/mutations/useFollowMutaton.ts
+++ b/src/hooks/mutations/useFollowMutaton.ts
@@ -5,7 +5,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { TOAST_MESSAGES } from "@constants/toast";
 import { Mypage } from "@@types/mypage";
 
-const useFollowMutations = (userId: Mypage["userId"]) => {
+const useFollowMutations = (userId: Mypage["userId"], restaurantId?: number) => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -14,6 +14,8 @@ const useFollowMutations = (userId: Mypage["userId"]) => {
       queryClient.invalidateQueries(["myPage", userId]);
       queryClient.invalidateQueries(["myFollowers", userId]);
       queryClient.invalidateQueries(["feedList", userId]);
+      queryClient.invalidateQueries(["feedList", undefined]);
+      restaurantId && queryClient.invalidateQueries(["restaurantDetail", restaurantId]);
     },
     onError: () => {
       toast(TOAST_MESSAGES.ERROR_PLEASE_RETRY);

--- a/src/hooks/queries/useFeedListQuery.ts
+++ b/src/hooks/queries/useFeedListQuery.ts
@@ -1,4 +1,4 @@
-import { APIFeedResponse, getFeedList, getFeedListByUserId } from "@/src/services/apiFeed";
+import { APIFeedResponse, getFeedList, getFeedListByUserId } from "@services/apiFeed";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 interface useFeedListQueryProps {

--- a/src/hooks/queries/useFeedListQuery.ts
+++ b/src/hooks/queries/useFeedListQuery.ts
@@ -1,0 +1,33 @@
+import { APIFeedResponse, getFeedList, getFeedListByUserId } from "@/src/services/apiFeed";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+interface useFeedListQueryProps {
+  userId?: number;
+  singleFeedId?: number;
+}
+
+const useFeedListQuery = ({ userId, singleFeedId }: useFeedListQueryProps) => {
+  return useInfiniteQuery(
+    ["feedList", userId],
+    async ({ pageParam = 0 }) => {
+      let response;
+      if (userId) {
+        response = await getFeedListByUserId(userId, pageParam);
+      } else {
+        response = await getFeedList(pageParam);
+      }
+
+      const apiResponse = response as unknown as APIFeedResponse;
+      return apiResponse;
+    },
+    {
+      getNextPageParam: (lastPage: APIFeedResponse) => {
+        if (lastPage?.response?.content?.length < 15) return undefined;
+        return lastPage?.response?.content[lastPage.response.content.length - 1]?.feed.feedId || 0;
+      },
+      enabled: !singleFeedId,
+    }
+  );
+};
+
+export default useFeedListQuery;

--- a/src/utils/ReactQueryProvider.tsx
+++ b/src/utils/ReactQueryProvider.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import React from "react";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 function ReactQueryProvider({ children }: React.PropsWithChildren) {
-  const [queryClient] = React.useState(new QueryClient({ defaultOptions: { queries: { staleTime: 5000 } } }));
+  const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 0 } } });
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## PR 타입

- [ ]  기능 추가
- [ ]  버그 수정
- [x]  코드 업데이트
- [x]  사소한 수정

## 👩‍🎤 작업 내용

- 메인 피드 페이지 카테고리화
- `react query`의 `staleTime` 기본값을 5000ms에서 0으로 변경
- 팔로우 버튼의 `mutate`시 invalid 되는 쿼리 키 추가

## 🧚 관련 issue
#208 


## 🙋🏼 공유할 사항 및 질문 사항
- 메인 페이지와 맛집 지도 페이지의 필터링 로직 추가 필요
