### PR TITLE
fix: 식당 피드 리스트 팔로우 버튼 rerender 수정, 피드 리스트의 멀티, 싱글 피드 리스트 구분 로직 수정

### DIFF
--- a/src/app/main/feed/page.tsx
+++ b/src/app/main/feed/page.tsx
@@ -6,11 +6,11 @@ import { useSearchParams } from "next/navigation";
 const UserSingleFeed = () => {
   const params = useSearchParams();
   const feedId = params.get("feedId");
-  const isFeeds = params.get("feeds");
+  const feedsId = params.get("feedsId");
 
   const feedsData = {
-    singleFeedId: isFeeds ? undefined : Number(feedId),
-    startingFeedId: isFeeds ? Number(feedId) : undefined,
+    singleFeedId: feedId ? Number(feedId) : undefined,
+    startingFeedId: feedsId ? Number(feedsId) : undefined,
   };
 
   return (

--- a/src/app/main/restaurants/[restaurantId]/feed/page.tsx
+++ b/src/app/main/restaurants/[restaurantId]/feed/page.tsx
@@ -1,8 +1,5 @@
-"use client";
-
-import Feeds from "@/src/components/Feed/Feeds";
+import RestaurantFeedsList from "@/src/components/Restaurant/RestaurtandFeedsList";
 import Header from "@components/Common/Header";
-import useRestaurantDetailQuery from "@hooks/queries/useRestaurantDetailQuery";
 
 interface RestaurantFeedProps {
   params: {
@@ -11,17 +8,10 @@ interface RestaurantFeedProps {
 }
 
 const RestaurantFeed = ({ params: { restaurantId } }: RestaurantFeedProps) => {
-  const parsedId = parseInt(restaurantId, 10);
-  const { data } = useRestaurantDetailQuery(parsedId);
-
   return (
     <div>
       <Header title="피드" back="prePage" />
-      {data?.feedList.map((feedData) => (
-        <div key={feedData.feed.feedId}>
-          <Feeds singleFeedId={feedData.feed.feedId} />
-        </div>
-      ))}
+      <RestaurantFeedsList restaurantId={restaurantId} />
     </div>
   );
 };

--- a/src/components/Feed/FeedsCategoryList.tsx
+++ b/src/components/Feed/FeedsCategoryList.tsx
@@ -30,7 +30,7 @@ const FeedsCategoryList = () => {
             {page.response.content.map((feedData: Content, dataIndex) => (
               <div key={dataIndex} className=" flex flex-col p-3 gap-3 border-gray-2 border-[1px] rounded-[10px]">
                 <div className="relative rounded-[10px] w-full aspect-w-1 aspect-h-1">
-                  <Link href={`/main/feed/?feeds?feedId=${feedData.feed.feedId}`}>
+                  <Link href={`/main/feed/?feedsId=${feedData.feed.feedId}`}>
                     <Image
                       className="rounded-[10px]"
                       src={feedData.feed.feedImages[0].imageUrl}

--- a/src/components/Restaurant/RestaurtandFeedsList.tsx
+++ b/src/components/Restaurant/RestaurtandFeedsList.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import useRestaurantDetailQuery from "@hooks/queries/useRestaurantDetailQuery";
+import Feed from "@components/Feed/Feed";
+
+interface RestaurantFeedsListProps {
+  restaurantId: string;
+}
+
+const RestaurantFeedsList = ({ restaurantId }: RestaurantFeedsListProps) => {
+  const parsedId = parseInt(restaurantId, 10);
+  const { data } = useRestaurantDetailQuery(parsedId);
+
+  return (
+    <>
+      {data?.feedList.map((feedData) => (
+        <div key={feedData.feed.feedId}>
+          <Feed {...feedData} />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default RestaurantFeedsList;


### PR DESCRIPTION
## PR 타입

- [ ]  기능 추가
- [x]  버그 수정
- [ ]  코드 업데이트
- [ ]  사소한 수정

## 👩‍🎤 작업 내용

- 식당 리스트의 팔로우 버튼 클릭시 `rerender`가 안되던 문제 해결 (`Feeds` 컴포넌트로 리페칭 된 데이터를 보내 다시 데이터를 받아오는 로직을 동작하는 대신 `Feed` 컴포넌트로 보내 바로 렌더링)
- main/home/feed 페이지로 이동한 경우, `feedId`가 있으면 싱글 피드, `feedsId`가 있으면 멀티 피드의 해당 피드 위치로 렌더링하도록 수정

## 🧚 관련 issue



## 🙋🏼 공유할 사항 및 질문 사항

