### PR TITLE
Refactor: 카카오 로그인 분기 처리 및 마이페이지 오류 수정

### DIFF
--- a/src/app/auth/kakao/page.tsx
+++ b/src/app/auth/kakao/page.tsx
@@ -3,12 +3,12 @@ import { useState } from "react";
 import Image from "next/image";
 import Button from "@components/Common/Button";
 import useSignUpStore from "@store/useSignUpStore";
-import SignUpProfile from "@components/Auth/SignUpProfile";
 import AuthHeader from "@components/Common/Header/Auth";
 import CustomModal from "@components/Common/Dialog/CustomModal";
 import { loginKaKaoToken } from "@services/kakao";
 import { useUserStore } from "@store/useUserStore";
 import { useToast } from "@/components/ui/use-toast";
+import { useRouter } from "next/navigation";
 
 function KaKaoSignUpTerms() {
   const [isLoading, setIsLoading] = useState(false);
@@ -17,9 +17,9 @@ function KaKaoSignUpTerms() {
   const [isCheckedInfo, setIsCheckedInfo] = useState(false);
   const isChecked = useSignUpStore((state) => state.isChecked);
   const setIsChecked = useSignUpStore((state) => state.setIsChecked);
-  const nextComponent = useSignUpStore((state) => state.nextComponent);
-  const setNextComponent = useSignUpStore((state) => state.setNextComponent);
   const setUser = useUserStore((state) => state.setUser);
+  const router = useRouter();
+
   const { toast } = useToast();
 
   const onChangeServiceHandler = () => {
@@ -38,28 +38,21 @@ function KaKaoSignUpTerms() {
 
   const onClickHandler = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-
+    setIsLoading(true);
     if (!isChecked || !isCheckedInfo) {
       return alert("이용약관 동의는 필수입니다.");
     }
-
-    const kakaoToken = localStorage.getItem("kakaoToken");
-
-    if (kakaoToken) {
-      setIsLoading(true);
-      await loginKaKaoToken(kakaoToken)
-        .then((res) => {
-          setNextComponent("SignUpProfile");
-          setUser(res.data.response);
-        })
-        .catch(() => toast({ description: "카카오 인증이 만료되었습니다." }))
-        .finally(() => setIsLoading(false));
+    try {
+      const kakaoToken = localStorage.getItem("kakaoToken");
+      if (!kakaoToken) throw new Error("인증 토큰이 없습니다. 다시 시도해주세요.");
+      const res = await loginKaKaoToken(kakaoToken);
+      setUser(res.data.response);
+      router.replace("/main/mypage/");
+    } catch (error) {
+      toast({ description: "카카오 인증이 만료되었습니다." });
     }
+    setIsLoading(false);
   };
-
-  if (nextComponent === "SignUpProfile") {
-    return <SignUpProfile />;
-  }
 
   return (
     <section className="flex flex-col items-center justify-center p-10 h-4/5 sm:w-[600px] sm:border border-gray-300">

--- a/src/components/Auth/KaKaoTerms.tsx
+++ b/src/components/Auth/KaKaoTerms.tsx
@@ -1,0 +1,129 @@
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+import Button from "@components/Common/Button";
+import useSignUpStore from "@store/useSignUpStore";
+import CustomModal from "@components/Common/Dialog/CustomModal";
+import { initializePushNotifications } from "@components/Notification/PushNotification";
+import { loginKaKaoToken } from "@services/kakao";
+import { useUserStore } from "@store/useUserStore";
+import { useToast } from "@/components/ui/use-toast";
+import { useRouter } from "next/navigation";
+import { TERMS, TOAST_MESSAGES } from "@constants";
+
+function KaKaoTerms() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [showServiceTerms, setShowServiceTerms] = useState(false);
+  const [showInfoTerms, setShowInfoTerms] = useState(false);
+  const [isCheckedInfo, setIsCheckedInfo] = useState(false);
+  const isChecked = useSignUpStore((state) => state.isChecked);
+  const setIsChecked = useSignUpStore((state) => state.setIsChecked);
+  const setUser = useUserStore((state) => state.setUser);
+  const router = useRouter();
+
+  const { toast } = useToast();
+
+  const onChangeServiceHandler = () => {
+    setIsChecked(!isChecked);
+  };
+
+  const onChangeInfoHandler = () => {
+    setIsCheckedInfo(!isCheckedInfo);
+  };
+
+  const onClickTermsBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setShowServiceTerms(false);
+    setShowInfoTerms(false);
+  };
+
+  const onClickHandler = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    if (!isChecked || !isCheckedInfo) {
+      return alert("이용약관 동의는 필수입니다.");
+    }
+    try {
+      const kakaoToken = localStorage.getItem("kakaoToken");
+      if (!kakaoToken) throw new Error("인증 토큰이 없습니다. 다시 시도해주세요.");
+      const res = await loginKaKaoToken(kakaoToken);
+      setUser(res.data.response);
+      initializePushNotifications();
+      router.replace("/main/mypage/");
+    } catch (error) {
+      router.replace("/accounts/login");
+      toast(TOAST_MESSAGES.KAKAO_LOGIN_FAILURE);
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <section className="flex flex-col items-center justify-center p-10 h-4/5 sm:w-[600px] sm:border border-gray-300">
+      <div className="mb-10">
+        <div className="title">
+          <h2>이용약관동의</h2>
+        </div>
+        <p>{TERMS.TITLE}</p>
+        <div className="flex items-center justify-between gap-x-3 mt-3">
+          <label className="flex items-center gap-3 flex-shrink-0">
+            <p>
+              서비스 이용 약관 동의 <span className="text-red-500">(필수)</span>
+            </p>
+            <input className="checkbox" type="checkbox" checked={isChecked} onChange={onChangeServiceHandler} />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => setShowServiceTerms(true)}
+            className="text-blue-400 underline underline-offset-1 flex-shrink-0"
+          >
+            내용 보기
+          </button>
+        </div>
+        <div className="flex items-center justify-between gap-x-3">
+          <label className="flex items-center gap-3 flex-shrink-0">
+            <p>
+              개인정보 수집∙이용 동의 <span className="text-red-500">(필수)</span>
+            </p>
+            <input className="checkbox" type="checkbox" checked={isCheckedInfo} onChange={onChangeInfoHandler} />
+          </label>
+          <button
+            type="button"
+            onClick={() => setShowInfoTerms(true)}
+            className="text-blue-400 underline underline-offset-1 flex-shrink-0"
+          >
+            내용 보기
+          </button>
+        </div>
+      </div>
+      <Button type="button" variant={"primary"} onClick={onClickHandler} disabled={isLoading}>
+        {isLoading ? "로딩중..." : "회원가입"}
+      </Button>
+      {showServiceTerms && (
+        <CustomModal>
+          <div className="p-3 text-sm">
+            <p>{TERMS.SERVICE.TITLE}</p>
+            <Image src="/images/terms.png" alt="service" width={300} height={300} />
+            <p className="mb-3">{TERMS.SERVICE.CONTENT}</p>
+            <Button type="button" onClick={onClickTermsBtn}>
+              확인
+            </Button>
+          </div>
+        </CustomModal>
+      )}
+
+      {showInfoTerms && (
+        <CustomModal>
+          <div className="p-3 text-[10px]">
+            <p className="h-[400px] overflow-y-scroll">{TERMS.INFO}</p>
+            <Button type="button" onClick={onClickTermsBtn}>
+              확인
+            </Button>
+          </div>
+        </CustomModal>
+      )}
+    </section>
+  );
+}
+
+export default KaKaoTerms;

--- a/src/components/Mypage/MyFeedThumbnail.tsx
+++ b/src/components/Mypage/MyFeedThumbnail.tsx
@@ -22,7 +22,7 @@ function MyFeedThumbnail({ userId }: MyFeedThumbnailProps) {
     {
       getNextPageParam: (lastPage) => {
         if (lastPage?.content?.length < 15) return undefined;
-        return lastPage?.content[lastPage.content.length - 1]?.feed.feedId || 0;
+        return lastPage?.content[lastPage.content.length - 1]?.feed.feedId;
       },
     }
   );

--- a/src/components/Mypage/MyProfile.tsx
+++ b/src/components/Mypage/MyProfile.tsx
@@ -78,7 +78,7 @@ function Mypage({ userId, option }: Mypage) {
             </div>
           </div>
         </div>
-        <div className="px-6 mb-[32px]">
+        <div className="mb-[32px]">
           <p>{data?.aboutMe}</p>
         </div>
         {option === "타인" ? (

--- a/src/components/Mypage/MyProfileSettings.tsx
+++ b/src/components/Mypage/MyProfileSettings.tsx
@@ -6,6 +6,7 @@ import { profileSetting } from "@services/kakao";
 import { useUserStore } from "@store/useUserStore";
 import { useToast } from "@/components/ui/use-toast";
 import { Input } from "@/components/ui/input";
+import { TOAST_MESSAGES } from "@constants";
 import Button from "@components/Common/Button";
 import Haeder from "@components/Common/Header";
 import MyProfileImage from "@components/Mypage/MyProfileImage";
@@ -16,7 +17,7 @@ function MyProfileSettings() {
     nickName: "",
     aboutMe: "",
   });
-
+  const [isLoading, setIsLoading] = useState(false);
   const [previewImage, setPreviewImage] = useState("");
   const [profileImage, setProfileImage] = useState<File>();
   const fileInput = useRef<HTMLInputElement>(null);
@@ -47,7 +48,7 @@ function MyProfileSettings() {
 
   const ProfileSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
+    setIsLoading(true);
     const formData = new FormData();
 
     const userData = {
@@ -62,9 +63,12 @@ function MyProfileSettings() {
     try {
       await profileSetting(formData);
       router.replace("/main/mypage");
-    } catch (error) {
-      toast({ description: "프로필 수정 다시 시도해 주세요." });
+    } catch (error: any) {
+      const ERROR_MESSAGE = error.response.data.error.message;
+      toast({ description: ERROR_MESSAGE || TOAST_MESSAGES.PROFILE_EDIT_FAILURE });
     }
+
+    setIsLoading(false);
   };
 
   const pickImageHandler = () => {
@@ -149,8 +153,8 @@ function MyProfileSettings() {
           </div>
         </div>
         <div className="my-10 px-2 flex-end">
-          <Button type="submit" variant={"primary"}>
-            프로필 설정
+          <Button type="submit" variant={"primary"} disabled={isLoading}>
+            {isLoading ? "수정 중" : "프로필 설정"}
           </Button>
         </div>
       </form>

--- a/src/components/Notification/NotifItem.tsx
+++ b/src/components/Notification/NotifItem.tsx
@@ -6,6 +6,7 @@ import FollowButton from "@components/Common/Button/FollowButton";
 import { Notification } from "@@types/apiTypes";
 
 function NotifItem({ ...notification }: Notification) {
+  // mention 추가 예정
   const { type, user, feed, reply, isFollowed, createdAt } = notification;
 
   const CONTENT_OPTION = {
@@ -20,6 +21,10 @@ function NotifItem({ ...notification }: Notification) {
     REPLY: {
       href: `/main/reply/${feed?.id}`,
       content: `님이 댓글을 남겼습니다:${reply?.content}`,
+    },
+    MENTION: {
+      href: `/main/reply/${feed?.id}`,
+      // content: `님이 댓글을 남겼습니다:${mention?.content}`,
     },
   };
 

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -23,4 +23,13 @@ export const TOAST_MESSAGES = {
   WITHDRAW_CANCEL: { description: "탈퇴를 취소했습니다." },
   WITHDRAW_SUCCESS: { title: "푸드로그 탈퇴", description: "회원 탈퇴되었습니다." },
   WITHDRAW_FAILURE: { title: "탈퇴 실패", description: "탈퇴 실패하였습니다." },
+  PROFILE_EDIT_FAILURE: { title: "수정 실패", description: "수정 중 에러 발생하였습니다." },
+  KAKAO_LOGIN_FAILURE: {
+    title: "카카오 로그인 실패",
+    description: "카카오 로그인 과정에서 에러가 발생하였습니다.\n 로그인 페이지로 이동합니다.",
+  },
+  KAKAO_LOGIN_WITHDRAW: {
+    title: "탈퇴 계정 가입 불가",
+    description: "탈퇴한 계정으로 재가입 불가합니다.\n 로그인 페이지로 이동합니다.",
+  },
 };

--- a/src/services/kakao.ts
+++ b/src/services/kakao.ts
@@ -57,7 +57,7 @@ export const profileSetting = async (body: FormData) => {
   return res;
 };
 
-//카카오 회원 탈퇴
+//카카오 연결 끊기 (탈퇴)
 export const unlinkKaKaoToken = async () => {
   const res = await kakaoLogoutRequest.post(`/unlink`);
   return res;
@@ -73,3 +73,23 @@ export const getKaKaoRefreshToken = async (token: string) => {
 
   return res;
 };
+
+// 카카오 연결 끊기 (fetch)
+// export const unlinkKaKao = async () => {
+//   const kakaoToken = localStorage.getItem("kakaoToken");
+//   const res = await fetch(
+//     `https://kapi.kakao.com/v1/user/unlink?client_secret=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_SECRE}`,
+//     {
+//       method: "POST",
+//       keepalive: true,
+//       headers: {
+//         "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+//         Authorization: `Bearer ${kakaoToken}`,
+//       },
+//     }
+//   );
+//   if (res.status === 200) {
+//     const json = await res.json();
+//     return json;
+//   } else return false;
+// };

--- a/src/services/mypage.ts
+++ b/src/services/mypage.ts
@@ -12,19 +12,11 @@ const headers = {
 export const getThumbnailByUserId = async (userId: number, feedId: number) => {
   let res;
   if (feedId === 0) {
-    res = await fetch(`${baseURL}/api/user/${userId}/feed`, {
-      method: "GET",
-      headers,
-    });
+    res = await userRequest.get(`${baseURL}/api/user/${userId}/feed`);
   } else {
-    res = await fetch(`${baseURL}/api/user/${userId}/feed/?feedId=${feedId}`, {
-      method: "GET",
-      headers,
-    });
+    res = await userRequest.get(`${baseURL}/api/user/${userId}/feed/?feedId=${feedId}`);
   }
-
-  const data = await res.json();
-  return data;
+  return res.data;
 };
 
 // 내 프로필 (fetch)


### PR DESCRIPTION
## PR 타입

- [x]  기능 추가
- [x]  버그 수정
- [x]  코드 업데이트
- [x]  사소한 수정

## 👩‍🎤 작업 내용
- 카카오 로그인 탈퇴 회원 분기 처리
- 마이페이지 썸네일 리스트 무한 에러 발생 오류 수정
- 썸네일 API axios로 마이그레이션
- 프로필 설정 페이지 디테일한 에러 핸들링, 로딩 비활성화 추가
- 알림 내역에 멘션 추가
- 기타 코드 리팩토링

## 🧚 관련 issue



## 🙋🏼 공유할 사항 및 질문 사항
- 현재 제 카카오 계정이 여러 테스트를 반복하면서 제대로 테스트가 안 되는 듯 합니다.
카카오 로그인 계정으로 테스트 가능하신 분 확인 부탁드립니다!
- 빌드 오류 부분은 추후에 해결하도록 하겠습니다!

